### PR TITLE
Run builds without the upload part on pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+  pull_request:
 
 jobs:
   builds:
@@ -36,6 +37,8 @@ jobs:
           path: ./wheelhouse/*.whl
 
   upload:
+    # Skip this step on pull requests. Run only when pushing a version tag.
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: builds
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This should make it much easier to be confident that a pull request is correct.