### PR TITLE
Delete ikatyang/tree-sitter-toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,9 +228,6 @@ form:
 * https://github.com/ikatyang/tree-sitter-markdown — licensed under the MIT
   License.
 
-* https://github.com/ikatyang/tree-sitter-toml — licensed under the MIT
-  License.
-
 * https://github.com/ikatyang/tree-sitter-yaml — licensed under the MIT
   License.
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,6 @@ git clone --depth 1 https://github.com/elm-tooling/tree-sitter-elm
 git clone --depth 1 https://github.com/fwcd/tree-sitter-kotlin
 git clone --depth 1 https://github.com/ganezdragon/tree-sitter-perl
 git clone --depth 1 https://github.com/ikatyang/tree-sitter-markdown
-git clone --depth 1 https://github.com/ikatyang/tree-sitter-toml
 git clone --depth 1 https://github.com/ikatyang/tree-sitter-yaml
 git clone --depth 1 https://github.com/jiyee/tree-sitter-objc
 git clone --depth 1 https://github.com/m-novikov/tree-sitter-sql


### PR DESCRIPTION
This will cause the next release to use https://github.com/tree-sitter/tree-sitter-toml, unlike the current latest release (1.2.2). Fixes #3.