### PR TITLE
Add support for arm64 macs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
           CIBW_SKIP: pp*
+          CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
It is already possible to use py-tree-sitter-languages on an arm64 mac, but only if you installed a Python that was meant for x86_64 macs, in which case it will automatically run under an emulator. After this PR you can use a "native" version of Python that is made for arm64 macs. It could be slightly faster than x86_64 python with emulation.

I can't test the wheels manually because I don't have a mac. Cibuildwheel doesn't test the wheels either (see warnings in CI output).