### PR TITLE
Adding linux aarch64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.9.0
 
@@ -33,6 +39,7 @@ jobs:
           CIBW_TEST_COMMAND: pytest --showlocals {package}/tests
           CIBW_SKIP: pp*
           CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_LINUX: auto aarch64
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Adding linux aarch64 builds resolving https://github.com/grantjenks/py-tree-sitter-languages/issues/26 following https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation. Tested on a Debian aarch64 vm running on apple silicon and looks to be working fine

I've only added aarch64 - not sure if there's a need for others?