### PR TITLE
chore: update cython, cibuildwheels, allowing CPython 3.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
         os: [ubuntu-20.04, macos-11, windows-2022]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -29,12 +29,12 @@ jobs:
           platforms: all
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.9.0
+        run: python -m pip install cibuildwheel==2.16.1
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_BUILD: pip install cython==0.29.32 && pip install -e . && python build.py
+          CIBW_BEFORE_BUILD: pip install cython==3.0.2 && pip install -e . && python build.py
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --showlocals {package}/tests
           CIBW_SKIP: pp*


### PR DESCRIPTION
This PR updates cibuildwheel and Cython, to allow building 3.12 wheels.

I've also updated some actions, with no apparent breaking changes.

The CI is currently passing for builds, [except for 3.12](https://github.com/GabDug/py-tree-sitter-languages/actions/runs/6395401877):

`py-tree-sitter` uses `distutils`, I created https://github.com/tree-sitter/py-tree-sitter/pull/161 in this regard but I'm open to other solutions :) 