### PR TITLE
Fix upload-artifact@v4 overwrite bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,8 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_BUILD_VERBOSITY: 3
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v2
         with:
-          overwrite: true
           name: wheelhouse
           path: ./wheelhouse/*.whl
 


### PR DESCRIPTION
The `overwrite` flag causes macOS and Windows wheels being overwritten by Ubuntu ones. This results in published packages with missing wheels.

https://github.com/actions/upload-artifact/tree/v4.0.0#breaking-changes