### PR TITLE
Migrate to upload-artifact@v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         run: python -m pip install cibuildwheel==2.16.2
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir dist
         env:
           CIBW_BEFORE_BUILD: pip install cython==3.0.8 && pip install -e . && python build.py
           CIBW_TEST_REQUIRES: pytest
@@ -42,10 +42,10 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_BUILD_VERBOSITY: 3
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
-          name: wheelhouse
-          path: ./wheelhouse/*.whl
+          name: wheelhouse-${{ matrix.os }}
+          path: dist
 
   upload:
     # Skip this step on pull requests. Run only when pushing a version tag.
@@ -61,11 +61,10 @@ jobs:
       - name: Stage wheels
         uses: actions/download-artifact@v4
         with:
-          name: wheelhouse
-          path: wheelhouse
+          pattern: wheelhouse-*
+          merge-multiple: true
+          path: dist
       - run: |
-          mkdir dist
-          mv -v wheelhouse/* dist/
           ls -l dist/
 
       - name: Publish package


### PR DESCRIPTION
It seems that the [build is failing](https://github.com/grantjenks/py-tree-sitter-languages/actions/runs/7720774276/job/21051244235#step:4:10) due to artefacts not being found. I think it is due to some compatibility issue between `upload-artifact@v2` and `download-artifact@v4`. 🤔

In this PR, I have reinstated `upload-artifact@v4` and ensured there are no naming conflicts (following the https://github.com/actions/upload-artifact/issues/478#issuecomment-1918746908 from `upload-artifact` repo). The artefact links are shown up in the log ([source](https://github.com/grantjenks/py-tree-sitter-languages/actions/runs/7724884957/job/21057942312?pr=49)).