### PR TITLE
Add tree-sitter-pkl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,9 @@ form:
 
 * https://github.com/rydesun/tree-sitter-dot — licensed under the MIT License.
 
+* https://github.com/apple/tree-sitter-pkl — licensed under the
+  Apache License, Version 2.0.
+
 * https://github.com/slackhq/tree-sitter-hack — licensed under the MIT
   License.
 

--- a/build.py
+++ b/build.py
@@ -77,6 +77,7 @@ Language.build_library(
         'vendor/tree-sitter-ocaml/ocaml',
         'vendor/tree-sitter-perl',
         'vendor/tree-sitter-php',
+        'vendor/tree-sitter-pkl',
         'vendor/tree-sitter-python',
         'vendor/tree-sitter-ql',
         'vendor/tree-sitter-r',

--- a/repos.txt
+++ b/repos.txt
@@ -37,6 +37,7 @@ https://github.com/tree-sitter/tree-sitter-json 3fef30de8aee74600f25ec2e319b62a1
 https://github.com/tree-sitter/tree-sitter-julia 0c088d1ad270f02c4e84189247ac7001e86fe342
 https://github.com/tree-sitter/tree-sitter-ocaml 4abfdc1c7af2c6c77a370aee974627be1c285b3b
 https://github.com/tree-sitter/tree-sitter-php 33e30169e6f9bb29845c80afaa62a4a87f23f6d6
+https://github.com/apple/tree-sitter-pkl c03f04a313b712f8ab00a2d862c10b37318699ae
 https://github.com/tree-sitter/tree-sitter-python 4bfdd9033a2225cc95032ce77066b7aeca9e2efc
 https://github.com/tree-sitter/tree-sitter-ql bd087020f0d8c183080ca615d38de0ec827aeeaf
 https://github.com/tree-sitter/tree-sitter-regex 2354482d7e2e8f8ff33c1ef6c8aa5690410fbc96

--- a/tests/test_tree_sitter_languages.py
+++ b/tests/test_tree_sitter_languages.py
@@ -35,6 +35,7 @@ LANGUAGES = [
     'ocaml',
     'perl',
     'php',
+    'pkl',
     'python',
     'ql',
     'r',


### PR DESCRIPTION
This changes adds the newly introduced tree-sitter-pkl repo created by Apple for the new Pkl programming configuration language.

https://pkl-lang.org/blog/introducing-pkl.html