### PR TITLE
Add tree-sitter-grammars/tree-sitter-tcl to languages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - v*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   builds:

--- a/README.rst
+++ b/README.rst
@@ -351,4 +351,8 @@ form:
 * https://github.com/stadelmanma/tree-sitter-fixed-form-fortran - licensed under
   the MIT License.
 
+* https://github.com/tree-sitter-grammars/tree-sitter-tcl - licensed under the MIT
+  License.
+
+
 .. _`tree-sitter`: https://tree-sitter.github.io/

--- a/build.py
+++ b/build.py
@@ -92,5 +92,6 @@ Language.build_library(
         'vendor/tree-sitter-typescript/tsx',
         'vendor/tree-sitter-typescript/typescript',
         'vendor/tree-sitter-yaml',
+        'vendor/tree-sitter-tcl'
     ]
 )

--- a/repos.txt
+++ b/repos.txt
@@ -46,3 +46,4 @@ https://github.com/tree-sitter/tree-sitter-scala 45b5ba0e749a8477a8fd2666f082f35
 https://github.com/tree-sitter/tree-sitter-toml 342d9be207c2dba869b9967124c679b5e6fd0ebe
 https://github.com/tree-sitter/tree-sitter-tsq b665659d3238e6036e22ed0e24935e60efb39415
 https://github.com/tree-sitter/tree-sitter-typescript d847898fec3fe596798c9fda55cb8c05a799001a
+https://github.com/tree-sitter-grammars/tree-sitter-tcl 78c71201c1b0939239e779a837dd35370c308948


### PR DESCRIPTION
Hey @grantjenks I just added the TCL language to the py package and it seems to be working pretty well so far.  

Thanks to @simonw  for his contributions in his [Blog post: Using tree-sitter with Python
](https://til.simonwillison.net/python/tree-sitter) helped me understand how to contribute to this.