### PR TITLE
Lock `tree-sitter` compatible version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ext_modules=cythonize('tree_sitter_languages/core.pyx', language_level='3'),
     packages=['tree_sitter_languages'],
     package_data={'tree_sitter_languages': ['languages.so', 'languages.dll']},
-    install_requires=['tree-sitter'],
+    install_requires=['tree-sitter<0.22'],
     project_urls={
         'Documentation': 'https://github.com/grantjenks/py-tree-sitter-languages',
         'Source': 'https://github.com/grantjenks/py-tree-sitter-languages',


### PR DESCRIPTION
Tree sitter [v0.22.0 introduced breaking changes](https://github.com/tree-sitter/py-tree-sitter/pull/208) which removed support for building custom languages and directly loading dll/so files through python, which seems to be a core feature of this library. As such I propose locking `tree-sitter` max supported version in `setup.py`

Resolves: #67