### PR TITLE
add tree-sitter-matlab

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           CIBW_BEFORE_BUILD: pip install cython==3.0.8 && pip install -e . && python build.py
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --showlocals {package}/tests
-          CIBW_SKIP: "{cp36**,pp*}"
+          CIBW_SKIP: "{cp36**,cp37**,pp*}"
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_BUILD_VERBOSITY: 3

--- a/README.rst
+++ b/README.rst
@@ -351,4 +351,7 @@ form:
 * https://github.com/stadelmanma/tree-sitter-fixed-form-fortran - licensed under
   the MIT License.
 
+* https://github.com/acristoffers/tree-sitter-matlab - licensed under
+  the MIT License.
+
 .. _`tree-sitter`: https://tree-sitter.github.io/

--- a/build.py
+++ b/build.py
@@ -73,6 +73,7 @@ Language.build_library(
         'vendor/tree-sitter-lua',
         'vendor/tree-sitter-make',
         'vendor/tree-sitter-markdown',
+        'vendor/tree-sitter-matlab',
         'vendor/tree-sitter-objc',
         'vendor/tree-sitter-ocaml/ocaml',
         'vendor/tree-sitter-perl',

--- a/repos.txt
+++ b/repos.txt
@@ -46,3 +46,4 @@ https://github.com/tree-sitter/tree-sitter-scala 45b5ba0e749a8477a8fd2666f082f35
 https://github.com/tree-sitter/tree-sitter-toml 342d9be207c2dba869b9967124c679b5e6fd0ebe
 https://github.com/tree-sitter/tree-sitter-tsq b665659d3238e6036e22ed0e24935e60efb39415
 https://github.com/tree-sitter/tree-sitter-typescript d847898fec3fe596798c9fda55cb8c05a799001a
+https://github.com/acristoffers/tree-sitter-matlab bbf1b3f0bd7417c1efb8958fe95be3d0d540207a

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ init = (pathlib.Path('tree_sitter_languages') / '__init__.py').read_text()
 match = re.search(r"^__version__ = '(.+)'$", init, re.MULTILINE)
 version = match.group(1)
 
+os.environ["MAKEFLAGS"] = "-j1"
+
 with open('README.rst') as reader:
     readme = reader.read()
 
@@ -23,7 +25,7 @@ setuptools.setup(
     ext_modules=cythonize('tree_sitter_languages/core.pyx', language_level='3'),
     packages=['tree_sitter_languages'],
     package_data={'tree_sitter_languages': ['languages.so', 'languages.dll']},
-    install_requires=['tree-sitter'],
+    install_requires=['tree-sitter~=0.21.3'],
     project_urls={
         'Documentation': 'https://github.com/grantjenks/py-tree-sitter-languages',
         'Source': 'https://github.com/grantjenks/py-tree-sitter-languages',

--- a/tests/test_tree_sitter_languages.py
+++ b/tests/test_tree_sitter_languages.py
@@ -31,6 +31,7 @@ LANGUAGES = [
     'lua',
     'make',
     'markdown',
+    'matlab',
     'objc',
     'ocaml',
     'perl',


### PR DESCRIPTION
- added https://github.com/acristoffers/tree-sitter-matlab to support Matlab
- pinned `tree-sitter` to `0.21` - latest version breaks build
-  disabled build for python v3.7
- set MAKEFLAGS to "-j1" to avoid build breaks under QEMU for arm 
-
